### PR TITLE
Use MiniTest instead of Test::Unit.

### DIFF
--- a/fauna.gemspec
+++ b/fauna.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'faraday', '~> 0.9.0'
   s.add_runtime_dependency 'json', '~> 1.8.0'
+  s.add_development_dependency 'minitest', '~> 5.1'
   s.add_development_dependency 'mocha', '>= 0'
   s.add_development_dependency 'rubocop', '>= 0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ libdir = File.dirname(File.dirname(__FILE__)) + '/lib'
 $LOAD_PATH.unshift libdir unless $LOAD_PATH.include?(libdir)
 
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
 require 'fauna'
 require 'securerandom'
 require 'mocha/setup'
@@ -16,7 +16,7 @@ unless FAUNA_ROOT_KEY
   fail 'FAUNA_ROOT_KEY must be defined in your environment to run tests.'
 end
 
-class FaunaTest < Test::Unit::TestCase
+class FaunaTest < MiniTest::Test
   def setup
     @root_client = get_client secret: FAUNA_ROOT_KEY
 


### PR DESCRIPTION
activemodel has MiniTest as a dependency.
This monkeypatches Test::Unit in a way that breaks it.
So, we might as well just use MiniTest.