### PR TITLE
simplify concat fn

### DIFF
--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -339,16 +339,12 @@ module Fauna
     # A concat function
     #
     # Reference: {FaunaDB String Functions}[https://faunadb.com/documentation/queries#string_functions]
-    def self.concat(*strings)
-      { concat: varargs(strings) }
-    end
-
-    ##
-    # A concat function with separator string
-    #
-    # Reference: {FaunaDB String Functions}[https://faunadb.com/documentation/queries#string_functions]
-    def self.concat_with_separator(separator, *strings)
-      { concat: varargs(strings), separator: separator }
+    def self.concat(strings, separator = nil)
+      if separator.nil?
+        { concat: strings }
+      else
+        { concat: strings, separator: separator }
+      end
     end
 
     ##

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -359,9 +359,9 @@ class QueryTest < FaunaTest
   end
 
   def test_concat
-    assert_query 'abc', Query.concat('a', 'b', 'c')
-    assert_query '', Query.concat
-    assert_query 'a.b.c', Query.concat_with_separator('.', 'a', 'b', 'c')
+    assert_query 'abc', Query.concat(['a', 'b', 'c'])
+    assert_query '', Query.concat([])
+    assert_query 'a.b.c', Query.concat(['a', 'b', 'c'], '.')
   end
 
   def test_casefold


### PR DESCRIPTION
concat_with_separator was needlessly differentiated to allow varargs.