### PR TITLE
dsl context block helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
 Lint/HandleExceptions:
   Enabled: false
 
+Lint/AmbiguousOperator:
+  Enabled: false
+
 Metrics/AbcSize:
   Enabled: false
 
@@ -62,7 +65,13 @@ Style/EachWithObject:
 Style/Encoding:
   Enabled: false
 
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+
 Style/Lambda:
+  Enabled: false
+
+Style/ModuleFunction:
   Enabled: false
 
 Style/RaiseArgs:
@@ -72,7 +81,7 @@ Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
 
 Style/TrailingComma:
-  EnforcedStyleForMultiline: 'comma'
+  Enabled: false
 
 Style/SingleLineBlockParams:
   Enabled: false

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -33,6 +33,32 @@ module Fauna
     end
 
     ##
+    # Issues a query to FaunaDB.
+    #
+    # Queries are built via the Query helpers. See {FaunaDB Query API}[https://faunadb.com/documentation/queries]
+    # for information on constructing queries.
+    #
+    # +expression+:: A query expression
+    # +expr_block+:: May be provided instead of expression. Block is used to build an expression with Fauna.query.
+    #
+    # Example using expression:
+    #
+    # <code>client.query(Fauna::Query.add(1, 2, Fauna::Query.subtract(3, 2)))</code>
+    #
+    # Example using block:
+    #
+    # <code>client.query { add(1, 2, subtract(3, 2)) }</code>
+    #
+    # :category: Query Methods
+    def query(expression = nil, &expr_block)
+      if expr_block.nil?
+        post('', expression)
+      else
+        post('', Fauna.query(&expr_block))
+      end
+    end
+
+    ##
     # Performs a +GET+ request for a REST endpoint.
     #
     # +path+:: Path to GET.
@@ -95,32 +121,6 @@ module Fauna
     # :category: REST Methods
     def delete(path, data = {})
       connection.delete(path.to_s, data)
-    end
-
-    ##
-    # Issues a query to FaunaDB.
-    #
-    # Queries are built via the Query helpers. See {FaunaDB Query API}[https://faunadb.com/documentation/queries]
-    # for information on constructing queries.
-    #
-    # +expression+:: A query expression
-    # +expr_block+:: May be provided instead of expression. Block is used to build an expression with Fauna.query.
-    #
-    # Example using expression:
-    #
-    # <code>client.query(Fauna::Query.add(1, 2, Fauna::Query.subtract(3, 2)))</code>
-    #
-    # Example using block:
-    #
-    # <code>client.query { add(1, 2, subtract(3, 2)) }</code>
-    #
-    # :category: Query Methods
-    def query(expression = nil, &expr_block)
-      if expr_block.nil?
-        post('', expression)
-      else
-        post('', Fauna.query(&expr_block))
-      end
     end
 
     ##

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -104,13 +104,14 @@ module Fauna
     # for information on constructing queries.
     #
     # +expression+:: A query expression
+    # +expr_block+:: May be provided instead of expression. Block is used to build an expression with Fauna.query.
     #
     # :category: Query Methods
-    def query(expression = nil, &block)
-      if block.nil?
+    def query(expression = nil, &expr_block)
+      if expr_block.nil?
         post('', expression)
       else
-        post('', Fauna.query(&block))
+        post('', Fauna.query(&expr_block))
       end
     end
 

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -106,8 +106,12 @@ module Fauna
     # +expression+:: A query expression
     #
     # :category: Query Methods
-    def query(expression)
-      post('', expression)
+    def query(expression = nil, &block)
+      if block.nil?
+        post('', expression)
+      else
+        post('', Fauna.query(&block))
+      end
     end
 
     ##

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -49,6 +49,8 @@ module Fauna
     #
     # <code>client.query { add(1, 2, subtract(3, 2)) }</code>
     #
+    # Reference: {Executing FaunaDB Queries}[https://faunadb.com/documentation#queries]
+    #
     # :category: Query Methods
     def query(expression = nil, &expr_block)
       if expr_block.nil?

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -106,6 +106,14 @@ module Fauna
     # +expression+:: A query expression
     # +expr_block+:: May be provided instead of expression. Block is used to build an expression with Fauna.query.
     #
+    # Example using expression:
+    #
+    # <code>client.query(Fauna::Query.add(1, 2, Fauna::Query.subtract(3, 2)))</code>
+    #
+    # Example using block:
+    #
+    # <code>client.query { add(1, 2, subtract(3, 2)) }</code>
+    #
     # :category: Query Methods
     def query(expression = nil, &expr_block)
       if expr_block.nil?

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -517,7 +517,7 @@ module Fauna
     end
 
     def method_missing(method, *args, &block)
-      ctx.send(method, *args, &block)
+      @__ctx__.send(method, *args, &block)
     end
   end
 end

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -62,24 +62,16 @@ module Fauna
     # An if expression
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
-    def if(condition, then_, else_)
-      { if: condition, then: then_, else: else_ }
-    end
-
     def if_(condition, then_, else_)
-      self.if(condition, then_, else_)
+      { if: condition, then: then_, else: else_ }
     end
 
     ##
     # A do expression
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
-    def do(*expressions)
-      { do: varargs(expressions) }
-    end
-
     def do_(*expressions)
-      self.do(*expressions)
+      { do: varargs(expressions) }
     end
 
     ##
@@ -464,36 +456,24 @@ module Fauna
     # An and function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def and(*booleans)
-      { and: varargs(booleans) }
-    end
-
     def and_(*booleans)
-      self.and(*booleans)
+      { and: varargs(booleans) }
     end
 
     ##
     # An or function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def or(*booleans)
-      { or: varargs(booleans) }
-    end
-
     def or_(*booleans)
-      self.or(*booleans)
+      { or: varargs(booleans) }
     end
 
     ##
     # A not function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def not(boolean)
-      { not: boolean }
-    end
-
     def not_(boolean)
-      self.not(boolean)
+      { not: boolean }
     end
 
   private

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -1,4 +1,7 @@
 module Fauna
+
+  extend self
+
   ##
   # Helpers modeling the FaunaDB \Query language.
   #
@@ -8,14 +11,17 @@ module Fauna
   # Example:
   #
   #   query = Fauna::Query.create(Fauna::Ref.new('classes', 'spells'), Fauna::Query.quote(data: { name: 'Magic Missile' }))
+
   module Query
+    extend self
+
     # :section: Values
 
     ##
     # An event
     #
     # Reference: {FaunaDB Values}[https://faunadb.com/documentation/queries#values]
-    def self.event(resource, ts, action)
+    def event(resource, ts, action)
       Event.new(resource, ts, action).to_hash
     end
 
@@ -25,7 +31,7 @@ module Fauna
     # A let expression
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
-    def self.let(vars, in_expr)
+    def let(vars, in_expr)
       { let: vars, in: in_expr }
     end
 
@@ -33,7 +39,7 @@ module Fauna
     # A var expression
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
-    def self.var(name)
+    def var(name)
       { var: name }
     end
 
@@ -41,7 +47,7 @@ module Fauna
     # An if expression
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
-    def self.if(condition, then_, else_)
+    def if(condition, then_, else_)
       { if: condition, then: then_, else: else_ }
     end
 
@@ -49,7 +55,7 @@ module Fauna
     # A do expression
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
-    def self.do(*expressions)
+    def do(*expressions)
       { do: varargs(expressions) }
     end
 
@@ -57,7 +63,7 @@ module Fauna
     # An object expression
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
-    def self.object(fields)
+    def object(fields)
       { object: fields }
     end
 
@@ -65,7 +71,7 @@ module Fauna
     # A quote expression
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
-    def self.quote(expr)
+    def quote(expr)
       { quote: expr }
     end
 
@@ -88,7 +94,7 @@ module Fauna
     #   Takes one or more ::var expressions and uses them to construct an expression.
     #   If this takes more than one argument, the lambda destructures an array argument.
     #   (To destructure single-element arrays use ::lambda_expr.)
-    def self.lambda(&block)
+    def lambda(&block)
       vars = block_parameters block
       case vars.length
       when 0
@@ -107,7 +113,7 @@ module Fauna
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
     #
     # See also ::lambda.
-    def self.lambda_expr(var, expr)
+    def lambda_expr(var, expr)
       { lambda: var, expr: expr }
     end
 
@@ -120,7 +126,7 @@ module Fauna
     # For example: <code>Fauna::Query.map(collection) { |a| Fauna::Query.add a, 1 }</code>.
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def self.map(collection, lambda_expr = nil, &lambda_block)
+    def map(collection, lambda_expr = nil, &lambda_block)
       { map: lambda_expr || lambda(&lambda_block), collection: collection }
     end
 
@@ -131,7 +137,7 @@ module Fauna
     # For example: <code>Fauna::Query.foreach(collection) { |a| Fauna::Query.delete a }</code>.
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def self.foreach(collection, lambda_expr = nil, &lambda_block)
+    def foreach(collection, lambda_expr = nil, &lambda_block)
       { foreach: lambda_expr || lambda(&lambda_block), collection: collection }
     end
 
@@ -142,7 +148,7 @@ module Fauna
     # For example: <code>Fauna::Query.filter(collection) { |a| Fauna::Query.equals a, 1 }</code>.
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def self.filter(collection, lambda_expr = nil, &lambda_block)
+    def filter(collection, lambda_expr = nil, &lambda_block)
       { filter: lambda_expr || lambda(&lambda_block), collection: collection }
     end
 
@@ -150,7 +156,7 @@ module Fauna
     # A take expression
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def self.take(number, collection)
+    def take(number, collection)
       { take: number, collection: collection }
     end
 
@@ -158,7 +164,7 @@ module Fauna
     # A drop expression
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def self.drop(number, collection)
+    def drop(number, collection)
       { drop: number, collection: collection }
     end
 
@@ -166,7 +172,7 @@ module Fauna
     # A prepend expression
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def self.prepend(elements, collection)
+    def prepend(elements, collection)
       { prepend: elements, collection: collection }
     end
 
@@ -174,7 +180,7 @@ module Fauna
     # An append expression
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def self.append(elements, collection)
+    def append(elements, collection)
       { append: elements, collection: collection }
     end
 
@@ -184,7 +190,7 @@ module Fauna
     # A get expression
     #
     # Reference: {FaunaDB Read functions}[https://faunadb.com/documentation/queries#read_functions]
-    def self.get(ref, params = {})
+    def get(ref, params = {})
       { get: ref }.merge(params)
     end
 
@@ -192,7 +198,7 @@ module Fauna
     # A paginate expression
     #
     # Reference: {FaunaDB Read functions}[https://faunadb.com/documentation/queries#read_functions]
-    def self.paginate(set, params = {})
+    def paginate(set, params = {})
       { paginate: set }.merge(params)
     end
 
@@ -200,7 +206,7 @@ module Fauna
     # An exists expression
     #
     # Reference: {FaunaDB Read functions}[https://faunadb.com/documentation/queries#read_functions]
-    def self.exists(ref, params = {})
+    def exists(ref, params = {})
       { exists: ref }.merge(params)
     end
 
@@ -208,7 +214,7 @@ module Fauna
     # A count expression
     #
     # Reference: {FaunaDB Read functions}[https://faunadb.com/documentation/queries#read_functions]
-    def self.count(set, params = {})
+    def count(set, params = {})
       { count: set }.merge(params)
     end
 
@@ -218,7 +224,7 @@ module Fauna
     # A create expression
     #
     # Reference: {FaunaDB Write functions}[https://faunadb.com/documentation/queries#write_functions]
-    def self.create(class_ref, params)
+    def create(class_ref, params)
       { create: class_ref, params: params }
     end
 
@@ -226,7 +232,7 @@ module Fauna
     # An update expression
     #
     # Reference: {FaunaDB Write functions}[https://faunadb.com/documentation/queries#write_functions]
-    def self.update(ref, params)
+    def update(ref, params)
       { update: ref, params: params }
     end
 
@@ -234,7 +240,7 @@ module Fauna
     # A replace expression
     #
     # Reference: {FaunaDB Write functions}[https://faunadb.com/documentation/queries#write_functions]
-    def self.replace(ref, params)
+    def replace(ref, params)
       { replace: ref, params: params }
     end
 
@@ -242,7 +248,7 @@ module Fauna
     # A delete expression
     #
     # Reference: {FaunaDB Write functions}[https://faunadb.com/documentation/queries#write_functions]
-    def self.delete(ref)
+    def delete(ref)
       { delete: ref }
     end
 
@@ -250,12 +256,12 @@ module Fauna
     # An insert expression
     #
     # Reference: {FaunaDB Write functions}[https://faunadb.com/documentation/queries#write_functions]
-    def self.insert(ref, ts, action, params)
+    def insert(ref, ts, action, params)
       { insert: ref, ts: ts, action: action, params: params }
     end
 
     # +insert+ that takes an +Event+ object instead of separate parameters.
-    def self.insert_event(event, params)
+    def insert_event(event, params)
       insert(event.resource, event.ts, event.action, params)
     end
 
@@ -263,12 +269,12 @@ module Fauna
     # A remove expression
     #
     # Reference: {FaunaDB Write functions}[https://faunadb.com/documentation/queries#write_functions]
-    def self.remove(ref, ts, action)
+    def remove(ref, ts, action)
       { remove: ref, ts: ts, action: action }
     end
 
     # +remove+ that takes an +Event+ object instead of separate parameters.
-    def self.remove_event(event)
+    def remove_event(event)
       remove(event.resource, event.ts, event.action)
     end
 
@@ -278,7 +284,7 @@ module Fauna
     # A match expression
     #
     # Reference: {FaunaDB Sets}[https://faunadb.com/documentation/queries#sets]
-    def self.match(terms, index)
+    def match(terms, index)
       { match: index, terms: terms }
     end
 
@@ -286,7 +292,7 @@ module Fauna
     # A union expression
     #
     # Reference: {FaunaDB Sets}[https://faunadb.com/documentation/queries#sets]
-    def self.union(*sets)
+    def union(*sets)
       { union: varargs(sets) }
     end
 
@@ -294,7 +300,7 @@ module Fauna
     # An intersection expression
     #
     # Reference: {FaunaDB Sets}[https://faunadb.com/documentation/queries#sets]
-    def self.intersection(*sets)
+    def intersection(*sets)
       { intersection: varargs(sets) }
     end
 
@@ -302,7 +308,7 @@ module Fauna
     # A difference expression
     #
     # Reference: {FaunaDB Sets}[https://faunadb.com/documentation/queries#sets]
-    def self.difference(*sets)
+    def difference(*sets)
       { difference: varargs(sets) }
     end
 
@@ -313,7 +319,7 @@ module Fauna
     # For example: <code>Fauna::Query.join(source) { |x| Fauna::Query.match x, some_index }</code>.
     #
     # Reference: {FaunaDB Sets}[https://faunadb.com/documentation/queries#sets]
-    def self.join(source, target_expr = nil, &target_block)
+    def join(source, target_expr = nil, &target_block)
       { join: source, with: target_expr || lambda(&target_block) }
     end
 
@@ -323,7 +329,7 @@ module Fauna
     # A concat function
     #
     # Reference: {FaunaDB String Functions}[https://faunadb.com/documentation/queries#string_functions]
-    def self.concat(strings, separator = nil)
+    def concat(strings, separator = nil)
       if separator.nil?
         { concat: strings }
       else
@@ -335,7 +341,7 @@ module Fauna
     # A casefold function
     #
     # Reference: {FaunaDB String Functions}[https://faunadb.com/documentation/queries#string_functions]
-    def self.casefold(string)
+    def casefold(string)
       { casefold: string }
     end
 
@@ -345,7 +351,7 @@ module Fauna
     # A time expression
     #
     # Reference: {FaunaDB Time Functions}[https://faunadb.com/documentation/queries#time_functions]
-    def self.time(string)
+    def time(string)
       { time: string }
     end
 
@@ -353,7 +359,7 @@ module Fauna
     # An epoch expression
     #
     # Reference: {FaunaDB Time Functions}[https://faunadb.com/documentation/queries#time_functions]
-    def self.epoch(number, unit)
+    def epoch(number, unit)
       { epoch: number, unit: unit }
     end
 
@@ -361,7 +367,7 @@ module Fauna
     # A date expression
     #
     # Reference: {FaunaDB Time Functions}[https://faunadb.com/documentation/queries#time_functions]
-    def self.date(string)
+    def date(string)
       { date: string }
     end
 
@@ -371,7 +377,7 @@ module Fauna
     # An equals function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation#queries-misc_functions]
-    def self.equals(*values)
+    def equals(*values)
       { equals: varargs(values) }
     end
 
@@ -379,7 +385,7 @@ module Fauna
     # A contains function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.contains(path, in_)
+    def contains(path, in_)
       { contains: path, in: in_ }
     end
 
@@ -387,7 +393,7 @@ module Fauna
     # A select function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.select(path, from, params = {})
+    def select(path, from, params = {})
       { select: path, from: from }.merge(params)
     end
 
@@ -395,7 +401,7 @@ module Fauna
     # An add function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.add(*numbers)
+    def add(*numbers)
       { add: varargs(numbers) }
     end
 
@@ -403,7 +409,7 @@ module Fauna
     # A multiply function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.multiply(*numbers)
+    def multiply(*numbers)
       { multiply: varargs(numbers) }
     end
 
@@ -411,7 +417,7 @@ module Fauna
     # A subtract function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.subtract(*numbers)
+    def subtract(*numbers)
       { subtract: varargs(numbers) }
     end
 
@@ -419,7 +425,7 @@ module Fauna
     # A divide function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.divide(*numbers)
+    def divide(*numbers)
       { divide: varargs(numbers) }
     end
 
@@ -427,7 +433,7 @@ module Fauna
     # A modulo function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.modulo(*numbers)
+    def modulo(*numbers)
       { modulo: varargs(numbers) }
     end
 
@@ -435,7 +441,7 @@ module Fauna
     # An and function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.and(*booleans)
+    def and(*booleans)
       { and: varargs(booleans) }
     end
 
@@ -443,7 +449,7 @@ module Fauna
     # An or function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.or(*booleans)
+    def or(*booleans)
       { or: varargs(booleans) }
     end
 
@@ -451,13 +457,13 @@ module Fauna
     # A not function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def self.not(boolean)
+    def not(boolean)
       { not: boolean }
     end
 
   private
 
-    def self.block_parameters(block)
+    def block_parameters(block)
       block.parameters.map do |kind, name|
         fail ArgumentError, 'Splat parameters are not supported in lambda expressions.' if kind == :rest
         name
@@ -469,8 +475,49 @@ module Fauna
     #
     # This ensures that a single value passed is not put in an array, so
     # <code>query.add([1, 2])</code> will work as well as <code>query.add(1, 2)</code>.
-    def self.varargs(values)
+    def varargs(values)
       values.length == 1 ? values[0] : values
+    end
+  end
+
+  def query(&block)
+    return nil if block.nil?
+
+    ctx = eval('self', block.binding)
+    dsl = DSLContext.new(ctx)
+
+    ctx.instance_variables.each do |iv|
+      dsl.instance_variable_set(iv, ctx.instance_variable_get(iv))
+    end
+
+    dsl.instance_exec(&block)
+
+  ensure
+    dsl.instance_variables.each do |iv|
+      if iv.to_sym != :@__ctx__
+        ctx.instance_variable_set(iv, dsl.instance_variable_get(iv))
+      end
+    end
+  end
+
+  class DSLContext
+    NON_PROXIED_METHODS = ::Set.new %w(__send__ object_id __id__ == equal?
+                                       ! != instance_exec instance_variables
+                                       instance_variable_get instance_variable_set
+                                    ).map(&:to_sym)
+
+    instance_methods.each do |method|
+      undef_method(method) unless NON_PROXIED_METHODS.include?(method.to_sym)
+    end
+
+    include Query
+
+    def initialize(ctx)
+      @__ctx__ = ctx
+    end
+
+    def method_missing(method, *args, &block)
+      ctx.send(method, *args, &block)
     end
   end
 end

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -1,7 +1,5 @@
 module Fauna
 
-  extend self
-
   ##
   # Helpers modeling the FaunaDB \Query language.
   #
@@ -11,6 +9,23 @@ module Fauna
   # Example:
   #
   #   query = Fauna::Query.create(Fauna::Ref.new('classes', 'spells'), Fauna::Query.quote(data: { name: 'Magic Missile' }))
+
+  ##
+  # Build a query expression.
+  #
+  # Allows for unscoped calls to Fauna::Query methods within the
+  # provided block. The block should return the constructed query
+  # expression.
+  #
+  # Example: <code>Fauna.query { add(1, 2, subtract(3, 2)) }</code>
+  def self.query(&block)
+    return nil if block.nil?
+
+    dsl = DSLContext.new
+    class << dsl; include Query; end
+
+    DSLContext.eval_dsl(dsl, &block)
+  end
 
   module Query
     extend self
@@ -497,59 +512,6 @@ module Fauna
     # <code>query.add([1, 2])</code> will work as well as <code>query.add(1, 2)</code>.
     def varargs(values)
       values.length == 1 ? values[0] : values
-    end
-  end
-
-  ##
-  # Build a query expression.
-  #
-  # Allows for unscoped calls to Fauna::Query methods within the
-  # provided block. The block should return the constructed query
-  # expression.
-  #
-  # Example: <code>Fauna.query { add(1, 2, subtract(3, 2)) }</code>
-  def query(&block)
-    return nil if block.nil?
-
-    dsl = DSLContext.new
-    class << dsl; include Query; end
-
-    DSLContext.eval_dsl(dsl, &block)
-  end
-
-  # :nodoc:
-  class DSLContext
-
-    # :nodoc:
-    def self.eval_dsl(dsl, &blk)
-      ctx = eval('self', blk.binding)
-      dsl.instance_variable_set(:@__ctx__, ctx)
-
-      ctx.instance_variables.each do |iv|
-        dsl.instance_variable_set(iv, ctx.instance_variable_get(iv))
-      end
-
-      dsl.instance_exec(&blk)
-
-    ensure
-      dsl.instance_variables.each do |iv|
-        if iv.to_sym != :@__ctx__
-          ctx.instance_variable_set(iv, dsl.instance_variable_get(iv))
-        end
-      end
-    end
-
-    NON_PROXIED_METHODS = ::Set.new %w(__send__ object_id __id__ == equal?
-                                       ! != instance_exec instance_variables
-                                       instance_variable_get instance_variable_set
-                                    ).map(&:to_sym)
-
-    instance_methods.each do |method|
-      undef_method(method) unless NON_PROXIED_METHODS.include?(method.to_sym)
-    end
-
-    def method_missing(method, *args, &block)
-      @__ctx__.send(method, *args, &block)
     end
   end
 end

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -1,15 +1,5 @@
 module Fauna
   ##
-  # Helpers modeling the FaunaDB \Query language.
-  #
-  # Helpers can be composed to build a query expression, which can then be passed to Client.query
-  # in order to execute the query.
-  #
-  # Example:
-  #
-  #   query = Fauna::Query.create(Fauna::Ref.new('classes', 'spells'), Fauna::Query.quote(data: { name: 'Magic Missile' }))
-
-  ##
   # Build a query expression.
   #
   # Allows for unscoped calls to Fauna::Query methods within the
@@ -26,6 +16,22 @@ module Fauna
     DSLContext.eval_dsl(dsl, &block)
   end
 
+  ##
+  # Helpers modeling the FaunaDB \Query language.
+  #
+  # Helpers can be used directly to build a query expression, or called via a more concise dsl notation.
+  #
+  # Example:
+  #
+  #   Fauna::Query.create(Fauna::Query.ref('classes', 'spells'), { data: { name: 'Magic Missile' } })
+  #
+  # DSL equivalent:
+  #
+  #   Fauna.query { create(ref('classes', 'spells'), { data: { name: 'Magic Missile' } }) }
+  #
+  # Query expressions are evaluated by passing them to Client#query, however Client#query may be directly passed a DSL block:
+  #
+  #   client.query { create(ref('classes', 'spells'), { data: { name: 'Magic Missile' } }) }
   module Query
     extend self
 

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -292,8 +292,8 @@ module Fauna
     # A match expression
     #
     # Reference: {FaunaDB Sets}[https://faunadb.com/documentation/queries#sets]
-    def match(terms, index)
-      { match: index, terms: terms }
+    def match(index, *terms)
+      { match: index, terms: varargs(terms) }
     end
 
     ##

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -51,12 +51,20 @@ module Fauna
       { if: condition, then: then_, else: else_ }
     end
 
+    def if_(condition, then_, else_)
+      self.if(condition, then_, else_)
+    end
+
     ##
     # A do expression
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
     def do(*expressions)
       { do: varargs(expressions) }
+    end
+
+    def do_(*expressions)
+      self.do(*expressions)
     end
 
     ##
@@ -445,6 +453,10 @@ module Fauna
       { and: varargs(booleans) }
     end
 
+    def and_(*booleans)
+      self.and(*booleans)
+    end
+
     ##
     # An or function
     #
@@ -453,12 +465,20 @@ module Fauna
       { or: varargs(booleans) }
     end
 
+    def or_(*booleans)
+      self.or(*booleans)
+    end
+
     ##
     # A not function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
     def not(boolean)
       { not: boolean }
+    end
+
+    def not_(boolean)
+      self.not(boolean)
     end
 
   private

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -503,8 +503,11 @@ module Fauna
   ##
   # Build a query expression.
   #
-  # Allows for unscoped calls to expression methods within the
-  # provided block.
+  # Allows for unscoped calls to Fauna::Query methods within the
+  # provided block. The block should return the constructed query
+  # expression.
+  #
+  # Example: <code>Fauna.query { add(1, 2, subtract(3, 2)) }</code>
   def query(&block)
     return nil if block.nil?
 

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -480,6 +480,10 @@ module Fauna
     end
   end
 
+  ##
+  # Build a query expression.
+  #
+  # Within the block, query expression constructor methods may be unscoped.
   def query(&block)
     return nil if block.nil?
 
@@ -500,6 +504,7 @@ module Fauna
     end
   end
 
+  # :nodoc:
   class DSLContext
     NON_PROXIED_METHODS = ::Set.new %w(__send__ object_id __id__ == equal?
                                        ! != instance_exec instance_variables

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -1,5 +1,4 @@
 module Fauna
-
   ##
   # Helpers modeling the FaunaDB \Query language.
   #

--- a/lib/fauna/util.rb
+++ b/lib/fauna/util.rb
@@ -14,4 +14,40 @@ module Fauna
   def self.usecs_from_time(time)
     time.to_i * 1_000_000 + time.usec
   end
+
+  # :nodoc:
+  class DSLContext
+
+    # :nodoc:
+    def self.eval_dsl(dsl, &blk)
+      ctx = eval('self', blk.binding)
+      dsl.instance_variable_set(:@__ctx__, ctx)
+
+      ctx.instance_variables.each do |iv|
+        dsl.instance_variable_set(iv, ctx.instance_variable_get(iv))
+      end
+
+      dsl.instance_exec(&blk)
+
+    ensure
+      dsl.instance_variables.each do |iv|
+        if iv.to_sym != :@__ctx__
+          ctx.instance_variable_set(iv, dsl.instance_variable_get(iv))
+        end
+      end
+    end
+
+    NON_PROXIED_METHODS = ::Set.new %w(__send__ object_id __id__ == equal?
+                                       ! != instance_exec instance_variables
+                                       instance_variable_get instance_variable_set
+                                    ).map(&:to_sym)
+
+    instance_methods.each do |method|
+      undef_method(method) unless NON_PROXIED_METHODS.include?(method.to_sym)
+    end
+
+    def method_missing(method, *args, &block)
+      @__ctx__.send(method, *args, &block)
+    end
+  end
 end

--- a/lib/fauna/util.rb
+++ b/lib/fauna/util.rb
@@ -17,7 +17,6 @@ module Fauna
 
   # :nodoc:
   class DSLContext
-
     # :nodoc:
     def self.eval_dsl(dsl, &blk)
       ctx = eval('self', blk.binding)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -69,8 +69,13 @@ class ClientTest < FaunaTest
   end
 
   def test_query
-    assert (client.query { paginate(Ref.new('classes')) })[:data].is_a?(Array)
-    assert client.query(Fauna.query { paginate(Ref.new('classes')) })[:data].is_a?(Array)
+    page1 = client.query { paginate(Ref.new('classes')) }
+    page2 = client.query(Fauna.query { paginate(Ref.new('classes')) })
+    page3 = client.query(Fauna::Query.paginate(Ref.new('classes')))
+
+    assert page1[:data].is_a?(Array)
+    assert_equal page1, page2
+    assert_equal page1, page3
   end
 
   def test_get

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -68,6 +68,11 @@ class ClientTest < FaunaTest
     assert_equal 'Scope All is OK', client.ping(scope: 'all')
   end
 
+  def test_query
+    assert (client.query { paginate(Ref.new('classes')) })[:data].is_a?(Array)
+    assert client.query(Fauna.query { paginate(Ref.new('classes')) })[:data].is_a?(Array)
+  end
+
   def test_get
     assert client.get('classes')[:data].is_a?(Array)
   end

--- a/test/objects_test.rb
+++ b/test/objects_test.rb
@@ -40,7 +40,7 @@ class ObjectsTest < FaunaTest
   end
 
   def test_set
-    match = Set.new Query.match(@ref, @index)
+    match = Set.new Query.match(@index, @ref)
     json_match = "{\"@set\":{\"match\":#{@json_index},\"terms\":#{@json_ref}}}"
     assert_equal match, parse_json(json_match)
     assert_equal json_match, to_json(match)

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -26,6 +26,11 @@ class QueryTest < FaunaTest
     @thimble_class_ref = client.post('classes', name: 'thimbles')[:ref]
   end
 
+  def test_query_helper_method_missing
+    foo = "foo"
+    assert_equal "foo", Fauna.query { foo }
+  end
+
   def test_let_var
     assert_query 1, Query.let({ x: 1 }, Query.var(:x))
   end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -57,6 +57,11 @@ class QueryTest < FaunaTest
     assert_equal({ x: 1 }, client.query { object({ x: let({x: 1}, var(:x)) }) })
   end
 
+  def test_quote
+    quoted = Fauna.query { let({x: 1}, var('x')) }
+    assert_equal quoted, client.query { quote(quoted) }
+  end
+
   def test_lambda
     assert_raises ArgumentError do
       Fauna.query { lambda {} }
@@ -65,14 +70,14 @@ class QueryTest < FaunaTest
     q = Fauna.query { lambda { |a| add(a, a) } }
     expr = { lambda: :a, expr: { add: [{ var: :a }, { var: :a }] } }
 
-    assert_equal expr.to_json, q.to_json
+    assert_equal expr, q
   end
 
   def test_lambda_multiple_args
     q = Fauna.query { lambda { |a, b| [b, a] } }
     expr = { lambda: [:a, :b], expr: [{ var: :b }, { var: :a }] }
 
-    assert_equal expr.to_json, q.to_json
+    assert_equal expr, q
     assert_equal [[2, 1], [4, 3]], client.query { map([[1, 2], [3, 4]], q) }
   end
 

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -95,7 +95,7 @@ class QueryTest < FaunaTest
 
   def test_foreach
     refs = [create_instance[:ref], create_instance[:ref]]
-    client.query(query { foreach(refs) { |a| delete a } })
+    client.query { foreach(refs) { |a| delete a } }
 
     refs.each do |ref|
       assert_equal false, client.query { exists(ref) }
@@ -229,22 +229,22 @@ class QueryTest < FaunaTest
   end
 
   def test_match
-    set = Query.match(WidgetsByN, 1)
+    set = Fauna.query { match(WidgetsByN, 1) }
     assert_equal [@ref_n1, @ref_n1m1], get_set_contents(set)
   end
 
   def test_union
-    set = query { union match(WidgetsByN, 1), match(WidgetsByM, 1) }
+    set = Fauna.query { union match(WidgetsByN, 1), match(WidgetsByM, 1) }
     assert_equal [@ref_n1, @ref_m1, @ref_n1m1], get_set_contents(set)
   end
 
   def test_intersection
-    set = query { intersection match(WidgetsByN, 1), match(WidgetsByM, 1) }
+    set = Fauna.query { intersection match(WidgetsByN, 1), match(WidgetsByM, 1) }
     assert_equal [@ref_n1m1], get_set_contents(set)
   end
 
   def test_difference
-    set = query { difference match(WidgetsByN, 1), match(WidgetsByM, 1) }
+    set = Fauna.query { difference match(WidgetsByN, 1), match(WidgetsByM, 1) }
     assert_equal [@ref_n1], get_set_contents(set)
   end
 

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -1,29 +1,36 @@
 require File.expand_path('../test_helper', __FILE__)
 
 class QueryTest < FaunaTest
+
+  Widgets = Ref.new('classes/widgets')
+  WidgetsByN = Ref.new('indexes/widgets_by_n')
+  WidgetsByM = Ref.new('indexes/widgets_by_m')
+  Thimbles = Ref.new('classes/thimbles')
+
   def setup
     super
 
-    @class_ref = client.post('classes', name: 'widgets')[:ref]
-    @n_index_ref = client.post(
+    client.post('classes', name: 'widgets')
+
+    client.post(
       'indexes',
       name: 'widgets_by_n',
-      source: @class_ref,
+      source: Widgets,
       path: 'data.n',
-      active: true)[:ref]
+      active: true)
 
-    @m_index_ref = client.post(
+    client.post(
       'indexes',
       name: 'widgets_by_m',
-      source: @class_ref,
+      source: Widgets,
       path: 'data.m',
-      active: true)[:ref]
+      active: true)
 
     @ref_n1 = create_instance(n: 1)[:ref]
     @ref_m1 = create_instance(m: 1)[:ref]
     @ref_n1m1 = create_instance(n: 1, m: 1)[:ref]
 
-    @thimble_class_ref = client.post('classes', name: 'thimbles')[:ref]
+    client.post('classes', name: 'thimbles')
   end
 
   def test_query_helper_method_missing
@@ -32,152 +39,138 @@ class QueryTest < FaunaTest
   end
 
   def test_let_var
-    assert_query 1, Query.let({ x: 1 }, Query.var(:x))
+    assert_equal 1, client.query { let({x: 1}, var(:x)) }
   end
 
   def test_if
-    assert_query 't', Query.if(true, 't', 'f')
-    assert_query 'f', Query.if(false, 't', 'f')
+    assert_equal 't', client.query { if_(true, 't', 'f') }
+    assert_equal 'f', client.query { if_(false, 't', 'f') }
   end
 
   def test_do
     instance = create_instance
-    assert_query 1, Query.do(Query.delete(instance[:ref]), 1)
-    assert_query false, Query.exists(instance[:ref])
+    assert_equal 1, client.query { do_(delete(instance[:ref]), 1) }
+    assert_equal false, client.query { exists(instance[:ref]) }
   end
 
   def test_object
-    # unlike quote, contents are evaluated
-    assert_query(
-      { x: 1 },
-      Query.object(x: Query.let({ x: 1 }, Query.var(:x))))
-  end
-
-  def test_quote
-    quoted = Query.let({ x: 1 }, Query.var('x'))
-    assert_query quoted, Query.quote(quoted)
+    assert_equal({ x: 1 }, client.query { object({ x: let({x: 1}, var(:x)) }) })
   end
 
   def test_lambda
     assert_raises ArgumentError do
-      Query.lambda {}
+      Fauna.query { lambda {} }
     end
 
-    assert_equal Query.lambda { |a| Query.add(a, a) },
-      lambda: :a,
-      expr: { add: [{ var: :a }, { var: :a }] }
+    q = Fauna.query { lambda { |a| add(a, a) } }
+    expr = { lambda: :a, expr: { add: [{ var: :a }, { var: :a }] } }
 
-    multi_args = Query.lambda { |a, b| [b, a] }
-    assert_equal({ lambda: [:a, :b], expr: [{ var: :b }, { var: :a }] }, multi_args)
-    assert_equal [[2, 1], [4, 3]], client.query(Query.map([[1, 2], [3, 4]], multi_args))
+    assert_equal expr.to_json, q.to_json
+  end
+
+  def test_lambda_multiple_args
+    q = Fauna.query { lambda { |a, b| [b, a] } }
+    expr = { lambda: [:a, :b], expr: [{ var: :b }, { var: :a }] }
+
+    assert_equal expr.to_json, q.to_json
+    assert_equal [[2, 1], [4, 3]], client.query { map([[1, 2], [3, 4]], q) }
   end
 
   def test_lambda_expr_vs_block
     # Use manual lambda: 2 args, no block
-    assert_query [2, 4, 6], Query.map([1, 2, 3], Query.lambda_expr(:a,
-      Query.multiply(2, Query.var(:a))))
+    assert_equal [2, 4, 6], client.query { map([1, 2, 3], lambda_expr(:a, multiply(2, var(:a)))) }
+    # Use lambda: 2 args, lambda
+    assert_equal [2, 4, 6], client.query { map([1, 2, 3], lambda { |a| multiply 2, a }) }
     # Use block lambda: only 1 arg
-    assert_query [2, 4, 6], (Query.map([1, 2, 3]) do |a|
-      Query.multiply 2, a
-    end)
+    assert_equal [2, 4, 6], client.query { map [1, 2, 3] { |a| multiply 2, a } }
   end
 
   def test_map
-    assert_query [2, 4, 6], (Query.map([1, 2, 3]) do |a|
-      Query.multiply 2, a
-    end)
+    assert_equal [2, 4, 6], client.query { map([1, 2, 3]) { |a| multiply 2, a } }
 
-    page = Query.paginate(n_set(1))
-    ns = Query.map page do |a|
-      Query.select([:data, :n], Query.get(a))
-    end
-    assert_query({ data: [1, 1] }, ns)
+    assert_equal({ data: [1, 1] }, client.query {
+      map paginate(match(WidgetsByN, 1)), lambda { |a| select([:data, :n], get(a)) }
+    })
   end
 
   def test_foreach
     refs = [create_instance[:ref], create_instance[:ref]]
-    client.query(Query.foreach(refs) do |a|
-      Query.delete a
-    end)
+    client.query(query { foreach(refs) { |a| delete a } })
+
     refs.each do |ref|
-      assert_query false, Query.exists(ref)
+      assert_equal false, client.query { exists(ref) }
     end
   end
 
   def test_filter
-    assert_query [2, 4], (Query.filter([1, 2, 3, 4]) do |a|
-      Query.equals Query.modulo(a, 2), 0
-    end)
+    assert_equal [2, 4], client.query { filter([1, 2, 3, 4]) { |a| equals modulo(a, 2), 0 } }
 
     # Works on page too
-    page = Query.paginate n_set(1)
-    refs_with_m = Query.filter(page) do |a|
-      Query.contains [:data, :m], Query.get(a)
-    end
-    assert_query({ data: [@ref_n1m1] }, refs_with_m)
+    assert_equal({ data: [@ref_n1m1] }, client.query {
+      filter(paginate(match(WidgetsByN, 1))) do |a|
+        contains [:data, :m], get(a)
+      end
+    })
   end
 
   def test_take
-    assert_query [1], Query.take(1, [1, 2])
-    assert_query [1, 2], Query.take(3, [1, 2])
-    assert_query [], Query.take(-1, [1, 2])
+    assert_equal [1], client.query { take(1, [1, 2]) }
+    assert_equal [1, 2], client.query { take(3, [1, 2]) }
+    assert_equal [], client.query { take(-1, [1, 2]) }
   end
 
   def test_drop
-    assert_query [2], Query.drop(1, [1, 2])
-    assert_query [], Query.drop(3, [1, 2])
-    assert_query [1, 2], Query.drop(-1, [1, 2])
+    assert_equal [2], client.query { drop(1, [1, 2]) }
+    assert_equal [], client.query { drop(3, [1, 2]) }
+    assert_equal [1, 2], client.query { drop(-1, [1, 2]) }
   end
 
   def test_prepend
-    assert_query [1, 2, 3, 4, 5, 6], Query.prepend([1, 2, 3], [4, 5, 6])
-    # Fails for non-array.
-    assert_bad_query Query.prepend([1, 2], 'foo')
+    assert_equal [1, 2, 3, 4, 5, 6], client.query { prepend([1, 2, 3], [4, 5, 6]) }
   end
 
   def test_append
-    assert_query [1, 2, 3, 4, 5, 6], Query.append([4, 5, 6], [1, 2, 3])
-    # Fails for non-array.
-    assert_bad_query Query.append([1, 2], 'foo')
+    assert_equal [1, 2, 3, 4, 5, 6], client.query { append([4, 5, 6], [1, 2, 3]) }
   end
 
   def test_get
     instance = create_instance
-    assert_query instance, Query.get(instance[:ref])
+    assert_equal instance, client.query { get(instance[:ref]) }
   end
 
   def test_paginate
-    test_set = n_set 1
+    test_set = Query.match(WidgetsByN, 1)
     control = [@ref_n1, @ref_n1m1]
-    assert_query({ data: control }, Query.paginate(test_set))
+    assert_equal({ data: control }, client.query { paginate(test_set) })
+
 
     data = []
-    page1 = client.query Query.paginate(test_set, size: 1)
+    page1 = client.query { paginate(test_set, size: 1) }
     data += page1[:data]
-    page2 = client.query Query.paginate(test_set, size: 1, after: page1[:after])
+    page2 = client.query { paginate(test_set, size: 1, after: page1[:after]) }
     data += page2[:data]
     assert_equal(control, data)
 
     response_with_sources = {
       data: [
-        { sources: [Set.new(test_set)], value: @ref_n1 },
-        { sources: [Set.new(test_set)], value: @ref_n1m1 },
+        { sources: [Set.new(match: WidgetsByN, terms: 1)], value: @ref_n1 },
+        { sources: [Set.new(match: WidgetsByN, terms: 1)], value: @ref_n1m1 },
       ],
     }
-    assert_query response_with_sources, Query.paginate(test_set, sources: true)
+    assert_equal response_with_sources, client.query { paginate(test_set, sources: true) }
   end
 
   def test_exists
     ref = create_instance[:ref]
-    assert_query true, Query.exists(ref)
-    client.query Query.delete(ref)
-    assert_query false, Query.exists(ref)
+    assert_equal true, client.query { exists(ref) }
+    client.query { delete(ref) }
+    assert_equal false, client.query { exists(ref) }
   end
 
   def test_count
     create_instance n: 123
     create_instance n: 123
-    instances = n_set 123
+    instances = Query.match(WidgetsByN, 123)
     # `count` is currently only approximate. Should be 2.
     assert client.query(Query.count(instances)).is_a? Integer
   end
@@ -186,22 +179,18 @@ class QueryTest < FaunaTest
     instance = create_instance
     assert instance.include? :ref
     assert instance.include? :ts
-    assert_equal @class_ref, instance[:class]
+    assert_equal Widgets, instance[:class]
   end
 
   def test_update
     ref = create_instance[:ref]
-    got = client.query Query.update(
-      ref,
-      Query.quote(data: { m: 1 }))
+    got = client.query { update(ref, quote(data: { m: 1 })) }
     assert_equal({ n: 0, m: 1 }, got[:data])
   end
 
   def test_replace
     ref = create_instance[:ref]
-    got = client.query Query.replace(
-      ref,
-      Query.quote(data: { m: 1 }))
+    got = client.query { replace(ref, quote(data: { m: 1 })) }
     assert_equal({ m: 1 }, got[:data])
   end
 
@@ -217,14 +206,10 @@ class QueryTest < FaunaTest
     ts = instance[:ts]
     prev_ts = ts - 1
     # Add previous event
-    inserted = Query.quote(data: { weight: 0 })
-    add = Query.insert(ref, prev_ts, :create, inserted)
-    client.query add
-    # Test alternate syntax
-    assert_equal add, Query.insert_event(Event.new(ref, prev_ts, :create), inserted)
+    client.query { insert(ref, prev_ts, :create, quote(data: { weight: 0 })) }
 
     # Get version from previous event
-    old = client.query Query.get(ref, ts: prev_ts)
+    old = client.query { get(ref, ts: prev_ts) }
     assert_equal({ weight: 0 }, old[:data])
   end
 
@@ -233,36 +218,33 @@ class QueryTest < FaunaTest
     ref = instance[:ref]
 
     # Change it
-    new_instance = client.query(Query.replace(ref, Query.quote(data: { weight: 1 })))
-    assert_equal new_instance, client.query(Query.get(ref))
+    new_instance = client.query { replace(ref, quote(data: { weight: 1 })) }
+    assert_equal new_instance, client.query { get(ref) }
 
     # Delete that event
-    remove = Query.remove(ref, new_instance[:ts], :create)
-    client.query remove
-    # Test alternate syntax
-    assert_equal remove, Query.remove_event(Event.new(ref, new_instance[:ts], :create))
+    client.query { remove(ref, new_instance[:ts], :create) }
 
     # Assert that it was undone
-    assert_equal instance, client.query(Query.get(ref))
+    assert_equal instance, client.query { get(ref) }
   end
 
   def test_match
-    set = n_set(1)
+    set = Query.match(WidgetsByN, 1)
     assert_equal [@ref_n1, @ref_n1m1], get_set_contents(set)
   end
 
   def test_union
-    set = Query.union n_set(1), m_set(1)
+    set = query { union match(WidgetsByN, 1), match(WidgetsByM, 1) }
     assert_equal [@ref_n1, @ref_m1, @ref_n1m1], get_set_contents(set)
   end
 
   def test_intersection
-    set = Query.intersection n_set(1), m_set(1)
+    set = query { intersection match(WidgetsByN, 1), match(WidgetsByM, 1) }
     assert_equal [@ref_n1m1], get_set_contents(set)
   end
 
   def test_difference
-    set = Query.difference n_set(1), m_set(1)
+    set = query { difference match(WidgetsByN, 1), match(WidgetsByM, 1) }
     assert_equal [@ref_n1], get_set_contents(set)
   end
 
@@ -270,31 +252,31 @@ class QueryTest < FaunaTest
     referenced = [create_instance(n: 12)[:ref], create_instance(n: 12)[:ref]]
     referencers = [create_instance(m: referenced[0])[:ref], create_instance(m: referenced[1])[:ref]]
 
-    source = n_set 12
+    source = Query.match(WidgetsByN, 12)
     assert_equal referenced, get_set_contents(source)
 
     # For each obj with n=12, get the set of elements whose data.m refers to it.
     set = Query.join source do |a|
-      Query.match a, @m_index_ref
+      Query.match WidgetsByM, a
     end
     assert_equal referencers, get_set_contents(set)
   end
 
   def test_concat
-    assert_query 'abc', Query.concat(['a', 'b', 'c'])
-    assert_query '', Query.concat([])
-    assert_query 'a.b.c', Query.concat(['a', 'b', 'c'], '.')
+    assert_equal 'abc', client.query { concat(['a', 'b', 'c']) }
+    assert_equal '', client.query { concat([]) }
+    assert_equal 'a.b.c', client.query { concat(['a', 'b', 'c'], '.') }
   end
 
   def test_casefold
-    assert_query 'hen wen', Query.casefold('Hen Wen')
+    assert_equal 'hen wen', client.query { casefold('Hen Wen') }
   end
 
   def test_time
     # `.round 9` is necessary because MRI 1.9.3 stores with greater precision than just nanoseconds.
     # This cuts it down to just nanoseconds so that the times compare as equal.
     time = Time.at(0, 123_456.789).round 9
-    assert_query time, Query.time('1970-01-01T00:00:00.123456789Z')
+    assert_equal time, client.query { time('1970-01-01T00:00:00.123456789Z') }
 
     # 'now' refers to the current time.
     assert client.query(Query.time('now')).is_a?(Time)
@@ -302,137 +284,109 @@ class QueryTest < FaunaTest
 
   def test_epoch
     secs = RandomHelper.random_number
-    assert_query Time.at(secs).utc, Query.epoch(secs, 'second')
+    assert_equal Time.at(secs).utc, client.query { epoch(secs, 'second') }
     nanos = RandomHelper.random_number
-    assert_query Time.at(Rational(nanos, 1_000_000_000)).utc, Query.epoch(nanos, 'nanosecond')
+    assert_equal Time.at(Rational(nanos, 1_000_000_000)).utc, client.query { epoch(nanos, 'nanosecond') }
   end
 
   def test_date
-    assert_query Date.new(1970, 1, 1), Query.date('1970-01-01')
+    assert_equal Date.new(1970, 1, 1), client.query { date('1970-01-01') }
   end
 
   def test_equals
-    assert_query true, Query.equals(1, 1, 1)
-    assert_query false, Query.equals(1, 1, 2)
-    assert_query true, Query.equals(1)
-    assert_bad_query Query.equals
+    assert_equal true, client.query { equals(1, 1, 1) }
+    assert_equal false, client.query { equals(1, 1, 2) }
+    assert_equal true, client.query { equals(1) }
   end
 
   def test_contains
-    obj = Query.quote a: { b: 1 }
-    assert_query true, Query.contains([:a, :b], obj)
-    assert_query true, Query.contains(:a, obj)
-    assert_query false, Query.contains([:a, :c], obj)
+    obj = Fauna.query { quote({ a: { b: 1 } }) }
+    assert_equal true, client.query { contains([:a, :b], obj) }
+    assert_equal true, client.query { contains(:a, obj) }
+    assert_equal false, client.query { contains([:a, :c], obj) }
   end
 
   def test_select
-    obj = Query.quote a: { b: 1 }
-    assert_query({ b: 1 }, Query.select(:a, obj))
-    assert_query 1, Query.select([:a, :b], obj)
-    assert_query nil, Query.select(:c, obj, default: nil)
+    obj = Fauna.query { quote({ a: { b: 1 } }) }
+    assert_equal({ b: 1 }, client.query { select(:a, obj) })
+    assert_equal 1, client.query { select([:a, :b], obj) }
+    assert_equal nil, client.query { select(:c, obj, default: nil) }
     assert_raises(NotFound) do
-      client.query Query.select(:c, obj)
+      client.query { select(:c, obj) }
     end
   end
 
   def test_select_array
     arr = [1, 2, 3]
-    assert_query 3, Query.select(2, arr)
+    assert_equal 3, client.query { select(2, arr) }
     assert_raises(NotFound) do
-      client.query Query.select(3, arr)
+      client.query { select(3, arr) }
     end
   end
 
   def test_add
-    assert_query 10, Query.add(2, 3, 5)
-    assert_bad_query Query.add
+    assert_equal 10, client.query { add(2, 3, 5) }
   end
 
   def test_multiply
-    assert_query 30, Query.multiply(2, 3, 5)
-    assert_bad_query Query.multiply
+    assert_equal 30, client.query { multiply(2, 3, 5) }
   end
 
   def test_subtract
-    assert_query(-6, Query.subtract(2, 3, 5))
-    assert_query 2, Query.subtract(2)
-    assert_bad_query Query.subtract
+    assert_equal -6, client.query { subtract(2, 3, 5) }
+    assert_equal 2, client.query { subtract(2) }
   end
 
   def test_divide
-    assert_query 2.0 / 15, Query.divide(2.0, 3, 5)
-    assert_query 2, Query.divide(2)
-    assert_bad_query Query.divide(1, 0)
-    assert_bad_query Query.divide
+    assert_equal 2.0 / 15, client.query { divide(2.0, 3, 5) }
+    assert_equal 2, client.query { divide(2) }
   end
 
   def test_modulo
-    assert_query 1, Query.modulo(5, 2)
+    assert_equal 1, client.query { modulo(5, 2) }
     # This is (15 % 10) % 2
-    assert_query 1, Query.modulo(15, 10, 2)
-    assert_query 2, Query.modulo(2)
-    assert_bad_query Query.modulo(1, 0)
-    assert_bad_query Query.modulo
+    assert_equal 1, client.query { modulo(15, 10, 2) }
+    assert_equal 2, client.query { modulo(2) }
   end
 
   def test_and
-    assert_query false, Query.and(true, true, false)
-    assert_query true, Query.and(true, true, true)
-    assert_query true, Query.and(true)
-    assert_query false, Query.and(false)
-    assert_bad_query Query.and
+    assert_equal false, client.query { and_(true, true, false) }
+    assert_equal true, client.query { and_(true, true, true) }
+    assert_equal true, client.query { and_(true) }
+    assert_equal false, client.query { and_(false) }
   end
 
   def test_or
-    assert_query true, Query.or(false, false, true)
-    assert_query false, Query.or(false, false, false)
-    assert_query true, Query.or(true)
-    assert_query false, Query.or(false)
-    assert_bad_query Query.or
+    assert_equal true, client.query { or_(false, false, true) }
+    assert_equal false, client.query { or_(false, false, false) }
+    assert_equal true, client.query { or_(true) }
+    assert_equal false, client.query { or_(false) }
   end
 
   def test_not
-    assert_query false, Query.not(true)
-    assert_query true, Query.not(false)
+    assert_equal false, client.query { not_(true) }
+    assert_equal true, client.query { not_(false) }
   end
 
   def test_varargs
     # Works for lists too
-    assert_query 10, Query.add([2, 3, 5])
+    assert_equal 10, client.query { add([2, 3, 5]) }
     # Works for a variable equal to a list
-    assert_query 10, Query.let({ x: [2, 3, 5] }, Query.add(Query.var(:x)))
+    assert_equal 10, client.query { let({x: [2, 3, 5]}, add(var(:x))) }
   end
 
 private
 
-  def n_set(n)
-    Query.match n, @n_index_ref
-  end
-
-  def m_set(m)
-    Query.match m, @m_index_ref
-  end
-
   def create_instance(data = {})
     data[:n] ||= 0
-    client.query Query.create(@class_ref, Query.quote(data: data))
+    client.query { create Widgets, quote(data: data) }
   end
 
   def create_thimble(data = {})
-    client.query Query.create(@thimble_class_ref, Query.quote(data: data))
+    client.query { create Thimbles, quote(data: data) }
   end
 
   def get_set_contents(set)
-    client.query(Query.paginate(set, size: 1000))[:data]
-  end
-
-  def assert_query(expected, query)
-    assert_equal expected, client.query(query)
-  end
-
-  def assert_bad_query(query)
-    assert_raises(BadRequest) do
-      client.query query
-    end
+    client.query { paginate(set, size: 1000) }[:data]
   end
 end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -34,12 +34,12 @@ class QueryTest < FaunaTest
   end
 
   def test_query_helper_method_missing
-    foo = "foo"
-    assert_equal "foo", Fauna.query { foo }
+    foo = 'foo'
+    assert_equal 'foo', Fauna.query { foo }
   end
 
   def test_let_var
-    assert_equal 1, client.query { let({x: 1}, var(:x)) }
+    assert_equal 1, client.query { let({ x: 1 }, var(:x)) }
   end
 
   def test_if
@@ -54,11 +54,11 @@ class QueryTest < FaunaTest
   end
 
   def test_object
-    assert_equal({ x: 1 }, client.query { object({ x: let({x: 1}, var(:x)) }) })
+    assert_equal({ x: 1 }, client.query { object(x: let({ x: 1 }, var(:x))) })
   end
 
   def test_quote
-    quoted = Fauna.query { let({x: 1}, var('x')) }
+    quoted = Fauna.query { let({ x: 1 }, var('x')) }
     assert_equal quoted, client.query { quote(quoted) }
   end
 
@@ -93,9 +93,9 @@ class QueryTest < FaunaTest
   def test_map
     assert_equal [2, 4, 6], client.query { map([1, 2, 3]) { |a| multiply 2, a } }
 
-    assert_equal({ data: [1, 1] }, client.query {
+    assert_equal({ data: [1, 1] }, client.query do
       map paginate(match(WidgetsByN, 1)), lambda { |a| select([:data, :n], get(a)) }
-    })
+    end)
   end
 
   def test_foreach
@@ -111,11 +111,11 @@ class QueryTest < FaunaTest
     assert_equal [2, 4], client.query { filter([1, 2, 3, 4]) { |a| equals modulo(a, 2), 0 } }
 
     # Works on page too
-    assert_equal({ data: [@ref_n1m1] }, client.query {
+    assert_equal({ data: [@ref_n1m1] }, client.query do
       filter(paginate(match(WidgetsByN, 1))) do |a|
         contains [:data, :m], get(a)
       end
-    })
+    end)
   end
 
   def test_take
@@ -148,7 +148,6 @@ class QueryTest < FaunaTest
     control = [@ref_n1, @ref_n1m1]
     assert_equal({ data: control }, client.query { paginate(test_set) })
 
-
     data = []
     page1 = client.query { paginate(test_set, size: 1) }
     data += page1[:data]
@@ -160,7 +159,7 @@ class QueryTest < FaunaTest
       data: [
         { sources: [Set.new(match: WidgetsByN, terms: 1)], value: @ref_n1 },
         { sources: [Set.new(match: WidgetsByN, terms: 1)], value: @ref_n1m1 },
-      ],
+      ]
     }
     assert_equal response_with_sources, client.query { paginate(test_set, sources: true) }
   end
@@ -305,19 +304,19 @@ class QueryTest < FaunaTest
   end
 
   def test_contains
-    obj = Fauna.query { quote({ a: { b: 1 } }) }
-    assert_equal true, client.query { contains([:a, :b], obj) }
-    assert_equal true, client.query { contains(:a, obj) }
-    assert_equal false, client.query { contains([:a, :c], obj) }
+    obj = { a: { b: 1 } }
+    assert_equal true, client.query { contains([:a, :b], quote(obj)) }
+    assert_equal true, client.query { contains(:a, quote(obj)) }
+    assert_equal false, client.query { contains([:a, :c], quote(obj)) }
   end
 
   def test_select
-    obj = Fauna.query { quote({ a: { b: 1 } }) }
-    assert_equal({ b: 1 }, client.query { select(:a, obj) })
-    assert_equal 1, client.query { select([:a, :b], obj) }
-    assert_equal nil, client.query { select(:c, obj, default: nil) }
+    obj = { a: { b: 1 } }
+    assert_equal({ b: 1 }, client.query { select(:a, quote(obj)) })
+    assert_equal 1, client.query { select([:a, :b], quote(obj)) }
+    assert_equal nil, client.query { select(:c, quote(obj), default: nil) }
     assert_raises(NotFound) do
-      client.query { select(:c, obj) }
+      client.query { select(:c, quote(obj)) }
     end
   end
 
@@ -377,7 +376,7 @@ class QueryTest < FaunaTest
     # Works for lists too
     assert_equal 10, client.query { add([2, 3, 5]) }
     # Works for a variable equal to a list
-    assert_equal 10, client.query { let({x: [2, 3, 5]}, add(var(:x))) }
+    assert_equal 10, client.query { let({ x: [2, 3, 5] }, add(var(:x))) }
   end
 
 private

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -33,9 +33,14 @@ class QueryTest < FaunaTest
     client.post('classes', name: 'thimbles')
   end
 
-  def test_query_helper_method_missing
-    foo = 'foo'
-    assert_equal 'foo', Fauna.query { foo }
+  def foo_method
+    'foo'
+  end
+
+  def test_query_helper_lexical_scope
+    bar_var = 'bar'
+    assert_equal 'foo', Fauna.query { foo_method }
+    assert_equal 'bar', Fauna.query { bar_var }
   end
 
   def test_let_var


### PR DESCRIPTION
Provides a helper to build a query using the dsl in an unscoped fashion:

```ruby
include Fauna

query do 
  create Ref.new('classes/foo'), object(data: object(foo: 'bar'))
end
```