### PR TITLE
Block-based let syntax

### DIFF
--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -50,9 +50,24 @@ module Fauna
     ##
     # A let expression
     #
+    # Example: <code>Fauna.query { let(x: 2).in(add(1, var(:x))) }</code>.
+    #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
-    def let(vars, in_expr)
-      { let: vars, in: in_expr }
+    def let(vars, in_expr = nil, &blk)
+      in_ = if blk.nil?
+        in_expr
+      else
+        dsl = DSLContext.new
+        dslcls = (class << dsl; include Query; self; end)
+
+        vars.keys.each do |v|
+          dslcls.send(:define_method, v) { var(v) }
+        end
+
+        DSLContext.eval_dsl(dsl, &blk)
+      end
+
+      { let: vars, in: in_ }
     end
 
     ##

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -54,7 +54,11 @@ module Fauna
     ##
     # A let expression
     #
-    # Example: <code>Fauna.query { let(x: 2) { add(1, x) } }</code>.
+    # Only one of \in_expr or blk should be provided.
+    #
+    # Block example: <code>Fauna.query { let(x: 2) { add(1, x) } }</code>.
+    #
+    # Expression example: <code>Fauna.query { let({ x: 2 }, add(1, var(:x))) }</code>.
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
     def let(vars, in_expr = nil, &blk)

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -10,8 +10,7 @@ module Fauna
   def self.query(&block)
     return nil if block.nil?
 
-    dsl = DSLContext.new
-    class << dsl; include Query; end
+    dsl = Query::QueryDSLContext.new
 
     DSLContext.eval_dsl(dsl, &block)
   end
@@ -35,6 +34,11 @@ module Fauna
   module Query
     extend self
 
+    # :nodoc:
+    class QueryDSLContext < DSLContext
+      include Query
+    end
+
     # :section: Values
 
     ##
@@ -57,8 +61,8 @@ module Fauna
       in_ = if blk.nil?
         in_expr
       else
-        dsl = DSLContext.new
-        dslcls = (class << dsl; include Query; self; end)
+        dsl = QueryDSLContext.new
+        dslcls = (class << dsl; self; end)
 
         vars.keys.each do |v|
           dslcls.send(:define_method, v) { var(v) }

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -54,7 +54,7 @@ module Fauna
     ##
     # A let expression
     #
-    # Example: <code>Fauna.query { let(x: 2).in(add(1, var(:x))) }</code>.
+    # Example: <code>Fauna.query { let(x: 2) { add(1, x) } }</code>.
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
     def let(vars, in_expr = nil, &blk)

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -44,7 +44,7 @@ class QueryTest < FaunaTest
   end
 
   def test_let_var
-    assert_equal 1, client.query { let({ x: 1 }, var(:x)) }
+    assert_equal 1, client.query { let(x: 1) { x } }
   end
 
   def test_if
@@ -59,11 +59,11 @@ class QueryTest < FaunaTest
   end
 
   def test_object
-    assert_equal({ x: 1 }, client.query { object(x: let({ x: 1 }, var(:x))) })
+    assert_equal({ x: 1 }, client.query { object(x: let(x: 1) { x }) })
   end
 
   def test_quote
-    quoted = Fauna.query { let({ x: 1 }, var('x')) }
+    quoted = Fauna.query { let(x: 1) { x } }
     assert_equal quoted, client.query { quote(quoted) }
   end
 
@@ -381,7 +381,7 @@ class QueryTest < FaunaTest
     # Works for lists too
     assert_equal 10, client.query { add([2, 3, 5]) }
     # Works for a variable equal to a list
-    assert_equal 10, client.query { let({ x: [2, 3, 5] }, add(var(:x))) }
+    assert_equal 10, client.query { let(x: [2, 3, 5]) { add(x) } }
   end
 
 private

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -64,7 +64,7 @@ class QueryTest < FaunaTest
 
   def test_quote
     quoted = Fauna.query { let(x: 1) { x } }
-    assert_equal quoted, client.query { quote(quoted) }
+    assert_equal quoted.to_json, client.query { quote(quoted) }.to_json
   end
 
   def test_lambda

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -45,6 +45,7 @@ class QueryTest < FaunaTest
 
   def test_let_var
     assert_equal 1, client.query { let(x: 1) { x } }
+    assert_equal 1, client.query { let({ x: 1 }, var(:x)) }
   end
 
   def test_if


### PR DESCRIPTION
uses DSLContext object to bind var refs to method handles:

```ruby
Fauna.query { let(x: 2) { add(1, x) } }
```