### PR TITLE
Add Expr wrapper to allow ruby hashes/arrays to be used as data.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,12 @@ Style/ModuleFunction:
 Style/RaiseArgs:
   Enabled: false
 
+Style/RedundantSelf:
+  Enabled: false
+
+Style/Semicolon:
+  Enabled: false
+
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
 

--- a/README.md
+++ b/README.md
@@ -59,14 +59,30 @@ $fauna = Fauna::Client.new(
 Now that we have a client, we can start performing queries:
 
 ```ruby
-# Create the user
-user = $fauna.query(Fauna::Query.create(Fauna::Ref.new('users'), Fauna::Query.quote('email' => 'taran@example.com')))
+# Create a class
+$fauna.query { create ref('classes'), name: 'users' }
 
-# Update the user's data
-user = $fauna.query(Fauna::Query.update(user['ref'], Fauna::Query.quote('data' => {'name' => 'Taran', 'profession' => 'Pigkeeper'})))
+# Create an instance of the class
+taran = $fauna.query do
+  create ref('classes/users'), data: { email: 'taran@example.com' }
+end
+
+# Update the instance
+taran = $fauna.query do
+  update taran[:ref], data: {
+    name: 'Taran',
+    profession: 'Pigkeeper'
+  }
+end
+
+# Page through a set
+pigkeepers = Fauna.query { match(ref('indexes/users_by_profession'), 'Pigkeeper') }
+oracles = Fauna.query { match(ref('indexes/users_by_profession'), Oracle') }
+
+$fauna.query { paginate(union(pigkeepers, oracles)) }
 
 # Delete the user
-$fauna.query(Fauna::Query.delete(user['ref']))
+$fauna.query { delete user[:ref] }
 ```
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ end
 
 # Page through a set
 pigkeepers = Fauna::Query.expr { match(ref('indexes/users_by_profession'), 'Pigkeeper') }
-oracles = Fauna::Query.expr { match(ref('indexes/users_by_profession'), Oracle') }
+oracles = Fauna::Query.expr { match(ref('indexes/users_by_profession'), 'Oracle') }
 
 $fauna.query { paginate(union(pigkeepers, oracles)) }
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ taran = $fauna.query do
 end
 
 # Page through a set
-pigkeepers = Fauna.query { match(ref('indexes/users_by_profession'), 'Pigkeeper') }
-oracles = Fauna.query { match(ref('indexes/users_by_profession'), Oracle') }
+pigkeepers = Fauna::Query.expr { match(ref('indexes/users_by_profession'), 'Pigkeeper') }
+oracles = Fauna::Query.expr { match(ref('indexes/users_by_profession'), Oracle') }
 
 $fauna.query { paginate(union(pigkeepers, oracles)) }
 

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -56,7 +56,7 @@ module Fauna
       if expr_block.nil?
         post '', Fauna::Query::Expr.wrap(expression)
       else
-        post '', Fauna.query(&expr_block)
+        post '', Fauna::Query.expr(&expr_block)
       end
     end
 

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -54,7 +54,7 @@ module Fauna
     # :category: Query Methods
     def query(expression = nil, &expr_block)
       if expr_block.nil?
-        post('', expression)
+        post('', Fauna::Query.send(:expr, expression))
       else
         post('', Fauna.query(&expr_block))
       end

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -54,9 +54,9 @@ module Fauna
     # :category: Query Methods
     def query(expression = nil, &expr_block)
       if expr_block.nil?
-        post('', Fauna::Query.send(:expr, expression))
+        post '', Fauna::Query::Expr.wrap(expression)
       else
-        post('', Fauna.query(&expr_block))
+        post '', Fauna.query(&expr_block)
       end
     end
 

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -1,5 +1,4 @@
 module Fauna
-
   ##
   # Build a query expression.
   #
@@ -63,7 +62,6 @@ module Fauna
       Expr.new object: expr_values(fields)
     end
 
-
     # :section: Basic forms
 
     ##
@@ -77,18 +75,19 @@ module Fauna
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
     def let(vars, in_expr = nil, &blk)
-      in_ = if blk.nil?
-        in_expr
-      else
-        dsl = QueryDSLContext.new
-        dslcls = (class << dsl; self; end)
+      in_ =
+        if blk.nil?
+          in_expr
+        else
+          dsl = QueryDSLContext.new
+          dslcls = (class << dsl; self; end)
 
-        vars.keys.each do |v|
-          dslcls.send(:define_method, v) { var(v) }
+          vars.keys.each do |v|
+            dslcls.send(:define_method, v) { var(v) }
+          end
+
+          DSLContext.eval_dsl(dsl, &blk)
         end
-
-        DSLContext.eval_dsl(dsl, &blk)
-      end
 
       Expr.new let: expr_values(vars), in: expr(in_)
     end
@@ -106,6 +105,7 @@ module Fauna
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
     def if_(condition, then_, else_)
+      # rubocop:disable Style/HashSyntax
       Expr.new :if => expr(condition), :then => expr(then_), :else => expr(else_)
     end
 
@@ -489,7 +489,7 @@ module Fauna
     # A not function
     #
     # Reference: {FaunaDB Miscellaneous Functions}[https://faunadb.com/documentation/queries#misc_functions]
-    def not(boolean)
+    def not_(boolean)
       Expr.new not: expr(boolean)
     end
 
@@ -524,7 +524,7 @@ module Fauna
     end
 
     def expr_values(obj)
-      obj.inject({}) { |h,(k,v)| h[k] = expr(v); h }
+      obj.inject({}) { |h, (k, v)| h[k] = expr(v); h }
     end
 
     def block_parameters(block)

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -105,8 +105,7 @@ module Fauna
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
     def if_(condition, then_, else_)
-      # rubocop:disable Style/HashSyntax
-      Expr.new :if => expr(condition), :then => expr(then_), :else => expr(else_)
+      Expr.new if: expr(condition), then: expr(then_), else: expr(else_)
     end
 
     ##
@@ -114,7 +113,7 @@ module Fauna
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
     def do_(*expressions)
-      Expr.new :do => varargs(expressions)
+      Expr.new do: varargs(expressions)
     end
 
     ##

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -1,42 +1,41 @@
 module Fauna
   ##
-  # Build a query expression.
-  #
-  # Allows for unscoped calls to Fauna::Query methods within the
-  # provided block. The block should return the constructed query
-  # expression.
-  #
-  # Example: <code>Fauna.query { add(1, 2, subtract(3, 2)) }</code>
-  def self.query(&block)
-    return nil if block.nil?
-
-    dsl = Query::QueryDSLContext.new
-
-    Query::Expr.wrap DSLContext.eval_dsl(dsl, &block)
-  end
-
-  ##
   # Helpers modeling the FaunaDB \Query language.
   #
-  # Helpers can be used directly to build a query expression, or called via a more concise dsl notation.
-  #
-  # Example:
-  #
-  #   Fauna::Query.create(Fauna::Query.ref('classes', 'spells'), { data: { name: 'Magic Missile' } })
-  #
-  # DSL equivalent:
-  #
-  #   Fauna.query { create(ref('classes', 'spells'), { data: { name: 'Magic Missile' } }) }
-  #
-  # Query expressions are evaluated by passing them to Client#query, however Client#query may be directly passed a DSL block:
+  # Helpers are usually used via a concise DSL notation. A DSL block
+  # may be used directly with Fauna::Client:
   #
   #   client.query { create(ref('classes', 'spells'), { data: { name: 'Magic Missile' } }) }
+  #
+  # To build and return an query expression to execute later, use Fauna::Query.expr:
+  #
+  #   Fauna::Query.expr { create(ref('classes', 'spells'), { data: { name: 'Magic Missile' } }) }
+  #
+  # Or, you may directly use the helper methods:
+  #
+  #   Fauna::Query.create(Fauna::Query.ref('classes', 'spells'), { data: { name: 'Magic Missile' } })
   module Query
     extend self
 
     # :nodoc:
     class QueryDSLContext < DSLContext
       include Query
+    end
+
+    ##
+    # Build a query expression.
+    #
+    # Allows for unscoped calls to Fauna::Query methods within the
+    # provided block. The block should return the constructed query
+    # expression.
+    #
+    # Example: <code>Fauna::Query.expr { add(1, 2, subtract(3, 2)) }</code>
+    def self.expr(&block)
+      return nil if block.nil?
+
+      dsl = QueryDSLContext.new
+
+      Expr.wrap DSLContext.eval_dsl(dsl, &block)
     end
 
     # :section: Values

--- a/lib/fauna/query.rb
+++ b/lib/fauna/query.rb
@@ -54,8 +54,8 @@ module Fauna
     #
     # Query expression constructs can also take a regular ruby object, so the following are equivalent:
     #
-    #   Fauna.query { object(x: 1, y: add(1, 2)) }
     #   Fauna.query { { x: 1, y: add(1, 2) } }
+    #   Fauna.query { object(x: 1, y: add(1, 2)) }
     #
     # Reference: {FaunaDB Basic Forms}[https://faunadb.com/documentation/queries#basic_forms]
     def object(fields)
@@ -163,34 +163,34 @@ module Fauna
     ##
     # A map expression
     #
-    # Only one of `lam` or `blk` should be provided.
+    # Only one of `lambda_expr` or `lambda_block` should be provided.
     # For example: <code>Fauna.query { map(collection) { |a| add a, 1 } }</code>.
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def map(collection, lam = nil, &blk)
-      Expr.new map: expr(lam || blk), collection: expr(collection)
+    def map(collection, lambda_expr = nil, &lambda_block)
+      Expr.new map: expr(lambda_expr || lambda_block), collection: expr(collection)
     end
 
     ##
     # A foreach expression
     #
-    # Only one of `lam` or `blk` should be provided.
+    # Only one of `lambda_expr` or `lambda_block` should be provided.
     # For example: <code>Fauna.query { foreach(collection) { |a| delete a } }</code>.
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def foreach(collection, lam = nil, &blk)
-      Expr.new foreach: expr(lam || blk), collection: expr(collection)
+    def foreach(collection, lambda_expr = nil, &lambda_block)
+      Expr.new foreach: expr(lambda_expr || lambda_block), collection: expr(collection)
     end
 
     ##
     # A filter expression
     #
-    # Only one of `lam` or `blk` should be provided.
+    # Only one of `lambda_expr` or `lambda_block` should be provided.
     # For example: <code>Fauna.query { filter(collection) { |a| equals a, 1 } }</code>.
     #
     # Reference: {FaunaDB Collections}[https://faunadb.com/documentation/queries#collection_functions]
-    def filter(collection, lam = nil, &blk)
-      Expr.new filter: expr(lam || blk), collection: expr(collection)
+    def filter(collection, lambda_expr = nil, &lambda_block)
+      Expr.new filter: expr(lambda_expr || lambda_block), collection: expr(collection)
     end
 
     ##
@@ -346,12 +346,12 @@ module Fauna
     ##
     # A join expression
     #
-    # Only one of `lam` or `blk` should be provided.
+    # Only one of `target_expr` or `target_blk` should be provided.
     # For example: <code>Fauna.query { join(source) { |x| match some_index, x } }</code>.
     #
     # Reference: {FaunaDB Sets}[https://faunadb.com/documentation/queries#sets]
-    def join(source, lam = nil, &blk)
-      Expr.new join: expr(source), with: expr(lam || blk)
+    def join(source, target_expr = nil, &target_blk)
+      Expr.new join: expr(source), with: expr(target_expr || target_blk)
     end
 
     # :section: String Functions

--- a/lib/fauna/util.rb
+++ b/lib/fauna/util.rb
@@ -37,8 +37,8 @@ module Fauna
     end
 
     NON_PROXIED_METHODS = Set.new %w(__send__ object_id __id__ == equal?
-                                    ! != instance_exec instance_variables
-                                    instance_variable_get instance_variable_set
+                                     ! != instance_exec instance_variables
+                                     instance_variable_get instance_variable_set
                                   ).map(&:to_sym)
 
     instance_methods.each do |method|

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -76,6 +76,9 @@ class ClientTest < FaunaTest
     assert page1[:data].is_a?(Array)
     assert_equal page1, page2
     assert_equal page1, page3
+
+    # hashes are still treated as objects.
+    assert_equal({ foo: 'bar' }, client.query(foo: 'bar'))
   end
 
   def test_get

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -70,7 +70,7 @@ class ClientTest < FaunaTest
 
   def test_query
     page1 = client.query { paginate(Ref.new('classes')) }
-    page2 = client.query(Fauna.query { paginate(Ref.new('classes')) })
+    page2 = client.query(Fauna::Query.expr { paginate(Ref.new('classes')) })
     page3 = client.query(Fauna::Query.paginate(Ref.new('classes')))
 
     assert page1[:data].is_a?(Array)

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../test_helper', __FILE__)
 class ErrorsTest < FaunaTest
   def test_request_result
     err = assert_raises(BadRequest) do
-      client.query foo: 'bar'
+      client.post '', foo: 'bar'
     end
     assert_equal({ foo: 'bar' }, err.request_result.request_content)
   end

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -80,14 +80,14 @@ class QueryTest < FaunaTest
     q = Fauna.query { lambda { |a| add(a, a) } }
     expr = { lambda: :a, expr: { add: [{ var: :a }, { var: :a }] } }
 
-    assert_equal expr, q
+    assert_equal expr.to_json, q.to_json
   end
 
   def test_lambda_multiple_args
     q = Fauna.query { lambda { |a, b| [b, a] } }
     expr = { lambda: [:a, :b], expr: [{ var: :b }, { var: :a }] }
 
-    assert_equal expr, q
+    assert_equal expr.to_json, q.to_json
     assert_equal [[2, 1], [4, 3]], client.query { map([[1, 2], [3, 4]], q) }
   end
 
@@ -326,7 +326,7 @@ class QueryTest < FaunaTest
     assert_equal 1, client.query { select([:a, :b], obj) }
     assert_equal nil, client.query { select(:c, obj, default: nil) }
     assert_raises(NotFound) do
-      client.query { select(:c, quote(obj)) }
+      client.query { select(:c, obj) }
     end
   end
 

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -41,8 +41,8 @@ class QueryTest < FaunaTest
 
   def test_query_helper_lexical_scope
     bar_var = 'bar'
-    assert_equal 'foo', Fauna.query { foo_method }
-    assert_equal 'bar', Fauna.query { bar_var }
+    assert_equal 'foo', Query.expr { foo_method }
+    assert_equal 'bar', Query.expr { bar_var }
   end
 
   def test_let_var
@@ -62,7 +62,7 @@ class QueryTest < FaunaTest
   end
 
   def test_hash_conversion
-    q = Fauna.query { { x: 1, y: { foo: 2 }, z: add(1, 2) } }
+    q = Query.expr { { x: 1, y: { foo: 2 }, z: add(1, 2) } }
     expr = { object: { x: 1, y: { object: { foo: 2 } }, z: { add: [1, 2] } } }
 
     assert_equal expr.to_json, q.to_json
@@ -74,17 +74,17 @@ class QueryTest < FaunaTest
 
   def test_lambda
     assert_raises ArgumentError do
-      Fauna.query { lambda {} }
+      Query.expr { lambda {} }
     end
 
-    q = Fauna.query { lambda { |a| add(a, a) } }
+    q = Query.expr { lambda { |a| add(a, a) } }
     expr = { lambda: :a, expr: { add: [{ var: :a }, { var: :a }] } }
 
     assert_equal expr.to_json, q.to_json
   end
 
   def test_lambda_multiple_args
-    q = Fauna.query { lambda { |a, b| [b, a] } }
+    q = Query.expr { lambda { |a, b| [b, a] } }
     expr = { lambda: [:a, :b], expr: [{ var: :b }, { var: :a }] }
 
     assert_equal expr.to_json, q.to_json
@@ -243,22 +243,22 @@ class QueryTest < FaunaTest
   end
 
   def test_match
-    set = Fauna.query { match(WidgetsByN, 1) }
+    set = Query.expr { match(WidgetsByN, 1) }
     assert_equal [@ref_n1, @ref_n1m1], get_set_contents(set)
   end
 
   def test_union
-    set = Fauna.query { union match(WidgetsByN, 1), match(WidgetsByM, 1) }
+    set = Query.expr { union match(WidgetsByN, 1), match(WidgetsByM, 1) }
     assert_equal [@ref_n1, @ref_m1, @ref_n1m1], get_set_contents(set)
   end
 
   def test_intersection
-    set = Fauna.query { intersection match(WidgetsByN, 1), match(WidgetsByM, 1) }
+    set = Query.expr { intersection match(WidgetsByN, 1), match(WidgetsByM, 1) }
     assert_equal [@ref_n1m1], get_set_contents(set)
   end
 
   def test_difference
-    set = Fauna.query { difference match(WidgetsByN, 1), match(WidgetsByM, 1) }
+    set = Query.expr { difference match(WidgetsByN, 1), match(WidgetsByM, 1) }
     assert_equal [@ref_n1], get_set_contents(set)
   end
 


### PR DESCRIPTION
Hashes are transformed to `object` builder calls. Has the nice effect of allowing data to be round-tripped.