### PR TITLE
Don't set cli.debug=true for Jruby CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - FAUNA_DOMAIN=rest.faunadb.com
   - FAUNA_SCHEME=https
   - FAUNA_PORT=443
-  - JRUBY_OPTS="-Xcli.debug=true --debug"
+  - JRUBY_OPTS="--debug"
 notifications:
   email: false
   slack:


### PR DESCRIPTION
According to simplecov this was needed to ensure coverage was correct, but it only looks like we really need `--debug`, and setting `-Xcli.debug=true` is making tests output unneeded debugging info in CI.