### PR TITLE
Lock version number as latest coveralls has a bug on ruby 1.9

### DIFF
--- a/fauna.gemspec
+++ b/fauna.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '~> 1.8'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'rubocop', '~> 0.35.0'
-  s.add_development_dependency 'coveralls', '~> 0.8.10'
+  s.add_development_dependency 'coveralls', '= 0.8.10'
 end


### PR DESCRIPTION
Specifically, `0.8.11` and `0.8.12` of coveralls is missing a require and is failing to report on Jruby and MRI 1.9. (See lemurheavy/coveralls-ruby#95)