### PR TITLE
Coveralls update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - FAUNA_SCHEME=https
   - FAUNA_PORT=443
   - JRUBY_OPTS="--debug"
+  - COVERALLS_PARALLEL=true
 notifications:
   email: false
   slack:

--- a/fauna.gemspec
+++ b/fauna.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json', '~> 1.8'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'rubocop', '~> 0.35.0'
-  s.add_development_dependency 'coveralls', '= 0.8.10'
+  s.add_development_dependency 'coveralls', '~> 0.8.13'
 end


### PR DESCRIPTION
The bug with coveralls on 1.9.x was fixed, so this updates us to use coveralls `~> 0.8.13`.