### PR TITLE
Use persistent connections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.1.1
+* Use persistent connections (via the `net-http-persistent` adapter) by default.
+
 2.1.0
 * Added paginate helper.
 * Improved exception messages (now include FaunaDB errors).

--- a/fauna.gemspec
+++ b/fauna.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'faraday', '~> 0.9.0'
+  s.add_runtime_dependency 'net-http-persistent', '~> 2.9.4'
   s.add_runtime_dependency 'json', '~> 1.8'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'rubocop', '~> 0.38.0'

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -46,7 +46,7 @@ module Fauna
       @read_timeout = params[:read_timeout] || 60
       @connection_timeout = params[:connection_timeout] || 60
       @observer = params[:observer]
-      @adapter = params[:adapter] || Faraday.default_adapter
+      @adapter = params[:adapter] || :net_http_persistent
       init_credentials(params[:secret])
 
       init_connection

--- a/lib/fauna/version.rb
+++ b/lib/fauna/version.rb
@@ -1,4 +1,4 @@
 module Fauna
   # The version of the Fauna gem
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end


### PR DESCRIPTION
Switching over to `net-http-persistent` as the Faraday adapter greatly increases performance for repeated connections, especially when using SSL on JRuby.