### PR TITLE
Wrap faraday errors

### DIFF
--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -237,6 +237,8 @@ module Fauna
         req.body = FaunaJson.to_json(data) unless data.nil?
         req.url(path || '')
       end
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+      raise UnavailableError.new(e)
     end
   end
 

--- a/lib/fauna/client.rb
+++ b/lib/fauna/client.rb
@@ -223,7 +223,7 @@ module Fauna
 
       @observer.call(request_result) unless @observer.nil?
 
-      if response_json.nil?
+      if response_json.nil? && response.status != 503
         fail UnexpectedError.new('Invalid JSON.', request_result)
       end
 

--- a/lib/fauna/errors.rb
+++ b/lib/fauna/errors.rb
@@ -55,34 +55,44 @@ module Fauna
       end
     end
 
-    # Creates a new error from a given RequestResult.
+    # Creates a new error from a given RequestResult or Exception.
     def initialize(request_result)
-      @request_result = request_result
-      errors_raw = UnexpectedError.get_or_raise request_result, request_result.response_content, :errors
-      @errors = catch :invalid_response do
-        throw :invalid_response unless errors_raw.is_a? Array
-        errors_raw.map { |error| ErrorData.from_hash(error) }
-      end
+      message = nil
 
-      if @errors.nil?
-        fail UnexpectedError.new('Error data has an unexpected format.', request_result)
-      elsif @errors.empty?
-        fail UnexpectedError.new('Error data returned was blank.', request_result)
-      end
+      if request_result.is_a? RequestResult
+        @request_result = request_result
 
-      message = @errors.map do |error|
-        msg = 'Error'
-        msg += " at #{error.position}" unless error.position.nil?
-        msg += ": #{error.code} - #{error.description}"
-
-        unless error.failures.nil?
-          msg += ' (' + error.failures.map do |failure|
-            "Failure at #{failure.field}: #{failure.code} - #{failure.description}"
-          end.join(' ') + ')'
+        errors_raw = UnexpectedError.get_or_raise request_result, request_result.response_content, :errors
+        @errors = catch :invalid_response do
+          throw :invalid_response unless errors_raw.is_a? Array
+          errors_raw.map { |error| ErrorData.from_hash(error) }
         end
 
-        msg
-      end.join(' ')
+        if @errors.nil?
+          fail UnexpectedError.new('Error data has an unexpected format.', request_result)
+        elsif @errors.empty?
+          fail UnexpectedError.new('Error data returned was blank.', request_result)
+        end
+
+        message = @errors.map do |error|
+          msg = 'Error'
+          msg += " at #{error.position}" unless error.position.nil?
+          msg += ": #{error.code} - #{error.description}"
+
+          unless error.failures.nil?
+            msg += ' (' + error.failures.map do |failure|
+              "Failure at #{failure.field}: #{failure.code} - #{failure.description}"
+            end.join(' ') + ')'
+          end
+
+          msg
+        end.join(' ')
+      elsif request_result.is_a? Exception
+        message = request_result.class.name
+        unless request_result.message.nil?
+          message += ": #{request_result.message}"
+        end
+      end
 
       super(message)
     end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe 'Fauna Errors' do
     Fauna::Client.new(adapter: [:test, stubs])
   end
 
+  # Create client with stub adapter responding to / with the given exception
+  def stub_error(exception)
+    stubs = Faraday::Adapter::Test::Stubs.new
+    stubs.get '/' do
+      fail exception
+    end
+    Fauna::Client.new(adapter: [:test, stubs])
+  end
+
   it 'sets request result' do
     expect { client.post '', foo: 'bar' }.to raise_error do |err|
       expect(err).to be_a(Fauna::BadRequest)
@@ -122,6 +131,16 @@ RSpec.describe 'Fauna Errors' do
     it 'handles upstream 503' do
       stub_client = stub_get 503, 'Unable to reach server'
       expect { stub_client.get '' }.to raise_error(Fauna::UnavailableError, 'Unable to reach server')
+    end
+
+    it 'handles timeout error' do
+      stub_client = stub_error Faraday::TimeoutError.new('timeout')
+      expect { stub_client.get '' }.to raise_error(Fauna::UnavailableError, 'Faraday::TimeoutError: timeout')
+    end
+
+    it 'handles connection error' do
+      stub_client = stub_error Faraday::ConnectionFailed.new('connection refused')
+      expect { stub_client.get '' }.to raise_error(Fauna::UnavailableError, 'Faraday::ConnectionFailed: connection refused')
     end
   end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -168,5 +168,9 @@ RSpec.describe 'Fauna Errors' do
     it 'raised for empty errors' do
       expect { stub_get(500, '{"errors": []}').get('') }.to raise_error(Fauna::UnexpectedError, /blank/)
     end
+
+    it 'raised for parsing error' do
+      expect { stub_error(Faraday::ParsingError.new('parse error')).get('') }.to raise_error(Fauna::UnexpectedError, /parse error/)
+    end
   end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -114,9 +114,14 @@ RSpec.describe 'Fauna Errors' do
   end
 
   describe Fauna::UnavailableError do
-    it 'is handled' do
+    it 'handles fauna 503' do
       stub_client = stub_get 503, '{"errors": [{"code": "unavailable", "description": "on vacation"}]}'
       expect { stub_client.get '' }.to raise_fauna_error(Fauna::UnavailableError, 'unavailable')
+    end
+
+    it 'handles upstream 503' do
+      stub_client = stub_get 503, 'Unable to reach server'
+      expect { stub_client.get '' }.to raise_error(Fauna::UnavailableError, 'Unable to reach server')
     end
   end
 


### PR DESCRIPTION
Wraps `Faraday::TimeoutError` and `Faraday::ConnectionError` with `Fauna::UnavailableError`. Also throws `Fauna::UnavailableError` for 503s even when we didn't get a valid JSON error back.