### PR TITLE
Add 'rdoc' to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
+gem 'rdoc'
 gem 'jruby-openssl', platform: :jruby
 
 gemspec


### PR DESCRIPTION
Tests on a fresh ruby install don't run under bundle exec, as rdoc doesn't get installed, and is required for running the build.