### PR TITLE
Force lower version of coveralls dependency

### DIFF
--- a/fauna.gemspec
+++ b/fauna.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'rubocop', '~> 0.38.0'
   s.add_development_dependency 'coveralls', '= 0.8.14'
+  s.add_development_dependency 'term-ansicolor', '~> 1.3.0'
 end


### PR DESCRIPTION
Coveralls is pulling in `term-ansicolor` with `~> 1.3` instead of `~> 1.3.0`, so it ends up pulling in 1.4 which doesn't work on ruby < 2.0. This forces it to stick to 1.3.x and allow travis to work.