### PR TITLE
Revise bytes handling

### DIFF
--- a/lib/fauna/objects.rb
+++ b/lib/fauna/objects.rb
@@ -125,10 +125,6 @@ module Fauna
 
     # Create new Bytes object from Base64 encoded bytes.
     def self.from_base64(enc)
-      if !enc.end_with?('=') && enc.length % 4 != 0
-        enc = enc.ljust((enc.length + 3) & ~3, '=')
-      end
-
       new(Base64.urlsafe_decode64(enc))
     end
   end

--- a/spec/bytes_spec.rb
+++ b/spec/bytes_spec.rb
@@ -11,14 +11,6 @@ RSpec.describe Fauna::Bytes do
       encoded = 'AQID'
       expect(Fauna::Bytes.from_base64(encoded).bytes).to eq("\x01\x02\x03")
     end
-
-    it 'does not require padding' do
-      pad = 'AQIDBA=='
-      no_pad = 'AQIDBA'
-
-      expect { Fauna::Bytes.from_base64(no_pad) }.not_to raise_error
-      expect(Fauna::Bytes.from_base64(no_pad)).to eq(Fauna::Bytes.from_base64(pad))
-    end
   end
 
   describe '#==' do

--- a/spec/bytes_spec.rb
+++ b/spec/bytes_spec.rb
@@ -1,31 +1,36 @@
 RSpec.describe Fauna::Bytes do
   describe '#initalize' do
     it 'creates from bytes' do
-      bytes = "\x01\x02\x03"
-      expect(Fauna::Bytes.new(bytes).bytes).to eq(bytes)
+      raw = random_bytes
+      expect(Fauna::Bytes.new(raw).bytes).to eq(raw)
     end
   end
 
   describe '#from_base64' do
     it 'creates from base64' do
-      encoded = 'AQID'
-      expect(Fauna::Bytes.from_base64(encoded).bytes).to eq("\x01\x02\x03")
+      raw = random_bytes
+      encoded = Base64.urlsafe_encode64(raw)
+
+      expect(Fauna::Bytes.from_base64(encoded).bytes).to eq(raw)
     end
   end
 
   describe '#==' do
     it 'equals same bytes' do
-      bytes = Fauna::Bytes.new("\x01\x02\x03")
+      raw = random_bytes
+      bytes = Fauna::Bytes.new(raw)
 
-      expect(bytes).to eq(Fauna::Bytes.new("\x01\x02\x03"))
+      expect(bytes).to eq(Fauna::Bytes.new(raw))
     end
 
     it 'does not equal different bytes' do
-      expect(Fauna::Bytes.new("\x04\x05\x06")).not_to eq(Fauna::Bytes.new("\x01\x02\x03"))
+      expect(Fauna::Bytes.new(random_bytes)).not_to eq(Fauna::Bytes.new(random_bytes))
     end
 
     it 'does not equal other type' do
-      expect(Fauna::Bytes.new("\x01\x02\x03")).not_to eq("\x01\x02\x03")
+      raw = random_bytes
+
+      expect(Fauna::Bytes.new(raw)).not_to eq(raw)
     end
   end
 end

--- a/spec/fauna_helper.rb
+++ b/spec/fauna_helper.rb
@@ -73,6 +73,10 @@ module FaunaTestHelpers
     SecureRandom.random_number(1_000_000)
   end
 
+  def random_bytes
+    SecureRandom.random_bytes(20)
+  end
+
   def random_ref_string
     "classes/#{random_string}/#{random_number}"
   end

--- a/spec/json_spec.rb
+++ b/spec/json_spec.rb
@@ -41,8 +41,10 @@ RSpec.describe Fauna::FaunaJson do
     end
 
     it 'deserializes bytes' do
-      data = { :@bytes => 'AQID' }
-      obj = Fauna::Bytes.new("\x01\x02\x03")
+      raw = random_bytes
+
+      data = { :@bytes => Base64.urlsafe_encode64(raw) }
+      obj = Fauna::Bytes.new(raw)
 
       expect(Fauna::FaunaJson.deserialize(data)).to eq(obj)
     end
@@ -108,8 +110,10 @@ RSpec.describe Fauna::FaunaJson do
     end
 
     it 'serializes bytes' do
-      data = { :@bytes => 'AQID' }
-      obj = Fauna::Bytes.new("\x01\x02\x03")
+      raw = random_bytes
+
+      data = { :@bytes => Base64.urlsafe_encode64(raw) }
+      obj = Fauna::Bytes.new(raw)
 
       expect(Fauna::FaunaJson.serialize(obj)).to eq(data)
     end


### PR DESCRIPTION
As FaunaDB is now padding the Base64 encoded bytes, we don't need to ensure padding ourselves, so this removes that. This also starts using random bytes for it's tests, instead of a static set of them.